### PR TITLE
Release/0.1.1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203,W503,E731

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,38 @@
+name: Bump
+
+on:
+  create:
+    branches:
+  workflow_dispatch:
+
+jobs:
+
+  bump-and-pr:
+
+    name: Bump
+
+    runs-on: ubuntu-latest
+
+    if: contains(github.ref, 'release/')
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Install poetry
+      run: pip install poetry
+
+    - name: Bump version
+      run: git branch --show-current | sed 's|release/||' | xargs poetry version | { printf '::set-output name=PR_TITLE::'; cat; }
+      id: bump
+
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        author: GitHub Actions <action@github.com>
+        commit-message: bump version
+        delete-branch: true
+        branch-suffix: short-commit-hash
+        title: ${{ steps.bump.outputs.PR_TITLE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,13 @@ on:
   push:
       branches:
       - main
+      - develop
       - release/*
       - hotfix/*
   pull_request:
       branches:
       - main
+      - develop
       - release/*
       - hotfix/*
   workflow_dispatch:
@@ -54,8 +56,7 @@ jobs:
       if: always()
 
     - name: Upload codecov report
-      run: |
-        python3 -m codecov
+      uses: codecov/codecov-action@v1
       if: ${{ matrix.python-version == '3.8' }}
 
   Lint:
@@ -65,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8']
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
       if: always()
 
     - name: Run black
-      run: |
-        python3 -m black --check ${PROJECT_NAME}
+      uses: psf/black@stable
+      with:
+        args: ". --check"
       if: always()
 
     - name: Run isort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,78 +19,96 @@ on:
   workflow_dispatch:
 
 jobs:
-  Test:
+
+  test:
+
     name: Test
 
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 6
       matrix:
         python-version: ['3.6', '3.7', '3.8']
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install package
+    - name: Install
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install .
         python3 -m pip install pytest pytest-cov codecov
 
     - name: Run doctest
-      run: |
-        python3 -m pytest --doctest-modules ${PROJECT_NAME}
+      run: python3 -m pytest --doctest-modules ${PROJECT_NAME}
       if: always()
 
     - name: Run pytest
-      run: |
-        python3 -m pytest --cov=${PROJECT_NAME} tests
+      run: python3 -m pytest --cov=${PROJECT_NAME} tests
       if: always()
 
     - name: Upload codecov report
       uses: codecov/codecov-action@v1
       if: ${{ matrix.python-version == '3.8' }}
 
-  Lint:
+  lint:
+
     name: Lint
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: ['3.8']
+    outputs:
+      status: ${{ job.status }}
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
+
+    - name: Lint (black)
+      uses: psf/black@21.5b1
+
+    - name: Format (isort)
+      uses: jamescurtin/isort-action@master
       with:
-        python-version: ${{ matrix.python-version }}
+        configuration: --check-only --diff --force-single-line
 
-    - name: Install linter
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install black isort
-      if: always()
+  format:
 
-    - name: Run black
-      uses: psf/black@stable
+    name: Format
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Format (black)
+      uses: psf/black@21.5b1
       with:
-        args: ". --check"
-      if: always()
+        options: '--skip-magic-trailing-comma'
 
-    - name: Run isort
-      run: |
-        python3 -m isort --check --force-single-line-imports ${PROJECT_NAME}
-      if: always()
+    - name: Format (black)
+      run: python -m pip install black && black .
+
+    - name: Format (isort)
+      uses: jamescurtin/isort-action@master
+      with:
+        configuration: '--force-single-line'
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        author: GitHub Actions <action@github.com>
+        commit-message: format
+        delete-branch: true
+        branch-suffix: short-commit-hash
+        title: Automated Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    needs: lint
+    
+    if: always() && needs.lint.outputs.status == 'failure'
+
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,7 @@ jobs:
     - name: Install linter
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install flake8 black isort
-      if: always()
-
-    - name: Run flake8
-      run: |
-        python3 -m flake8 ${PROJECT_NAME}
+        python3 -m pip install black isort
       if: always()
 
     - name: Run black

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PROJECT_NAME := pfhedge
+
+.PHONY: install
+install:
+	@poetry install
+
+.PHONY: test
+test:
+	@poetry run pytest --doctest-modules $(PROJECT_NAME)
+	@poetry run pytest --doctest-modules tests
+
+.PHONY: lint
+lint:
+	@poetry run black --check --quiet .
+	@poetry run isort --check --force-single-line-imports --quiet .
+
+.PHONY: format
+format:
+	@poetry run black --quiet .
+	@poetry run isort --force-single-line-imports --quiet .

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ pip install pfhedge
 
 ## How to Use
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pfnet-research/pfhedge/blob/main/examples/example_readme.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)][example-readme-colab]
 
 ### Prepare a Derivative to Hedge
 
@@ -267,3 +267,4 @@ This project is owned by [Preferred Networks](https://www.preferred.jp/en/) and 
 [whalley-wilmott]: https://doi.org/10.1111/1467-9965.00034
 [NoTransactionBandNetwork]: https://github.com/pfnet-research/NoTransactionBandNetwork
 [CONTRIBUTING.md]: https://github.com/pfnet-research/pfhedge/blob/master/CONTRIBUTING.md
+[example-readme-colab]: https://colab.research.google.com/github/pfnet-research/pfhedge/blob/main/examples/example_readme.ipynb

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ pip install pfhedge
 
 ## How to Use
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/pfnet-reseaarch/pfhedge/examples/example_readme.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pfnet-research/pfhedge/blob/main/examples/example_readme.ipynb)
 
 ### Prepare a Derivative to Hedge
 

--- a/examples/example_black_scholes.py
+++ b/examples/example_black_scholes.py
@@ -6,10 +6,10 @@ import torch
 
 sys.path.append("..")
 
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
-from pfhedge.nn import BlackScholes  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
+from pfhedge.nn import BlackScholes
 
 if __name__ == "__main__":
     torch.manual_seed(42)

--- a/examples/example_expected_shortfall.py
+++ b/examples/example_expected_shortfall.py
@@ -6,11 +6,11 @@ import torch
 
 sys.path.append("..")
 
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
 from pfhedge.nn import ExpectedShortfall
-from pfhedge.nn import MultiLayerPerceptron  # noqa: E402
+from pfhedge.nn import MultiLayerPerceptron
 
 if __name__ == "__main__":
     torch.manual_seed(42)

--- a/examples/example_module_output.py
+++ b/examples/example_module_output.py
@@ -7,15 +7,15 @@ import torch
 
 sys.path.append("..")
 
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.features import LogMoneyness  # noqa: E402
-from pfhedge.features import ExpiryTime  # noqa: E402
-from pfhedge.features import Volatility  # noqa: E402
-from pfhedge.features import ModuleOutput  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
-from pfhedge.nn import BlackScholes  # noqa: E402
-from pfhedge.nn import MultiLayerPerceptron  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.features import ExpiryTime
+from pfhedge.features import LogMoneyness
+from pfhedge.features import ModuleOutput
+from pfhedge.features import Volatility
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
+from pfhedge.nn import BlackScholes
+from pfhedge.nn import MultiLayerPerceptron
 
 if __name__ == "__main__":
     torch.manual_seed(42)

--- a/examples/example_multi_layer_perceptrons.py
+++ b/examples/example_multi_layer_perceptrons.py
@@ -6,10 +6,10 @@ import torch
 
 sys.path.append("..")
 
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
-from pfhedge.nn import MultiLayerPerceptron  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
+from pfhedge.nn import MultiLayerPerceptron
 
 if __name__ == "__main__":
     torch.manual_seed(42)

--- a/examples/example_no_transaction_band.py
+++ b/examples/example_no_transaction_band.py
@@ -8,12 +8,12 @@ import torch
 import torch.nn.functional as fn
 
 sys.path.append("..")
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
-from pfhedge.nn import BlackScholes  # noqa: E402
-from pfhedge.nn import Clamp  # noqa: E402
-from pfhedge.nn import MultiLayerPerceptron  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
+from pfhedge.nn import BlackScholes
+from pfhedge.nn import Clamp
+from pfhedge.nn import MultiLayerPerceptron
 
 
 class NoTransactionBandNet(torch.nn.Module):

--- a/examples/example_readme.ipynb
+++ b/examples/example_readme.ipynb
@@ -15,7 +15,7 @@
     }
    ],
    "source": [
-    "!pip install --quiet torch pytorch-pfn-extras tqdm"
+    "!pip install pfhedge"
    ]
   },
   {
@@ -57,17 +57,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "\n",
-    "sys.path.append(\"..\")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
    "outputs": [
@@ -85,8 +74,15 @@
    "source": [
     "torch.manual_seed(42)\n",
     "\n",
+    "if not torch.cuda.is_available():\n",
+    "    raise RuntimeWarning(\n",
+    "        \"CUDA is not available. \"\n",
+    "        \"If you're using Google Colab, you can enable GPUs as: \"\n",
+    "        \"https://colab.research.google.com/notebooks/gpu.ipynb\"\n",
+    "    )\n",
+    "\n",
     "DEVICE = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
-    "DEVICE"
+    "print(\"Default device:\", DEVICE)"
    ]
   },
   {
@@ -133,7 +129,7 @@
    "source": [
     "We consider a `BrownianStock`, which is a stock following the geometric Brownian motion, and a `EuropeanOption` which is contingent on it.\n",
     "\n",
-    "We assume that the stock has a transaction cost of 1 basis point."
+    "We assume that the stock has a transaction cost given by `cost`."
    ]
   },
   {
@@ -153,7 +149,7 @@
    "source": [
     "from pfhedge.instruments import BrownianStock, EuropeanOption\n",
     "\n",
-    "stock = BrownianStock(cost=1e-4)\n",
+    "stock = BrownianStock(cost=1e-3)\n",
     "deriv = EuropeanOption(stock).to(DEVICE)"
    ]
   },
@@ -731,16 +727,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": ""
   }
  },
  "nbformat": 4,

--- a/examples/example_whalley_wilmott.py
+++ b/examples/example_whalley_wilmott.py
@@ -6,10 +6,10 @@ import sys
 import torch
 
 sys.path.append("..")
-from pfhedge import Hedger  # noqa: E402
-from pfhedge.instruments import BrownianStock  # noqa: E402
-from pfhedge.instruments import EuropeanOption  # noqa: E402
-from pfhedge.nn import WhalleyWilmott  # noqa: E402
+from pfhedge import Hedger
+from pfhedge.instruments import BrownianStock
+from pfhedge.instruments import EuropeanOption
+from pfhedge.nn import WhalleyWilmott
 
 if __name__ == "__main__":
     torch.manual_seed(42)

--- a/pfhedge/__init__.py
+++ b/pfhedge/__init__.py
@@ -1,3 +1,1 @@
-# flake8: noqa
-
 from .hedger import Hedger

--- a/pfhedge/features/__init__.py
+++ b/pfhedge/features/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from ._getter import FEATURES
 from ._getter import get_feature
 from .features import Barrier

--- a/pfhedge/instruments/__init__.py
+++ b/pfhedge/instruments/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from .american_binary import AmericanBinaryOption
 from .european import EuropeanOption
 from .european_binary import EuropeanBinaryOption

--- a/pfhedge/nn/__init__.py
+++ b/pfhedge/nn/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from .bs.american_binary import BSAmericanBinaryOption
 from .bs.bs import BlackScholes
 from .bs.european import BSEuropeanOption

--- a/pfhedge/stochastic/__init__.py
+++ b/pfhedge/stochastic/__init__.py
@@ -1,4 +1,2 @@
-# flake8: noqa
-
 from .brownian import generate_brownian
 from .brownian import generate_geometric_brownian

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ tqdm = "^4.59.0"
 pytest = "^6.2.2"
 black = "^20.8b1"
 isort = "^5.7.0"
-flake8 = "^3.8.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Deep Hedging in PyTorch"
 authors = ["Shota Imaki <shota.imaki.0801@gmail.com>"]
 license = "MIT"
+repository = "https://github.com/pfnet-research/pfhedge"
 
 [tool.poetry.dependencies]
 python = "^3.6.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,25 +22,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]
-line-length = 88
-target-version = ['py37']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-)
-'''
+skip-magic-trailing-comma = true
 
 [tool.isort]
 profile = 'black'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pfhedge"
-version = "0.1.0"
+version = "0.1.1"
 description = "Deep Hedging in PyTorch"
 authors = ["Shota Imaki <shota.imaki.0801@gmail.com>"]
 license = "MIT"

--- a/test.sh
+++ b/test.sh
@@ -3,8 +3,5 @@
 python3 -m pytest --doctest-modules pfhedge
 python3 -m pytest --doctest-modules tests
 
-python3 -m flake8 pfhedge
-python3 -m black --check --quiet pfhedge || read -p "Run black? (y/n): " yn; [[ $yn = [yY] ]] && python3 -m black --quiet pfhedge
-python3 -m isort --check --force-single-line-imports pfhedge || read -p "Run isort? (y/n): " yn; [[ $yn = [yY] ]] && python3 -m isort --force-single-line-imports --quiet pfhedge
-python3 -m black --quiet tests
-python3 -m isort --force-single-line-imports --quiet tests
+python3 -m black --quiet .
+python3 -m isort --force-single-line-imports --quiet .

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,0 @@
-#!/bin/sh -eu
-
-python3 -m pytest --doctest-modules pfhedge
-python3 -m pytest --doctest-modules tests
-
-python3 -m black --quiet .
-python3 -m isort --force-single-line-imports --quiet .

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -298,11 +298,7 @@ class TestMaxMoneyness(_TestFeature):
     def test(self, strike, log):
         liability = EuropeanOption(BrownianStock(), strike=strike)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 2.0, 3.0],
-                [2.0, 3.0, 2.0],
-                [1.5, 4.0, 1.0],
-            ]
+            [[1.0, 2.0, 3.0], [2.0, 3.0, 2.0], [1.5, 4.0, 1.0]]
         )
 
         f = MaxMoneyness(log=log).of(liability)
@@ -339,11 +335,7 @@ class TestMaxLogMoneyness(_TestFeature):
     def test(self, strike):
         liability = EuropeanOption(BrownianStock(), strike=strike)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 2.0, 3.0],
-                [2.0, 3.0, 2.0],
-                [1.5, 4.0, 1.0],
-            ]
+            [[1.0, 2.0, 3.0], [2.0, 3.0, 2.0], [1.5, 4.0, 1.0]]
         )
 
         f = MaxLogMoneyness().of(liability)

--- a/tests/instruments/test_american_binary.py
+++ b/tests/instruments/test_american_binary.py
@@ -17,11 +17,7 @@ class TestAmericanBinaryOption:
     def test_payoff(self):
         liability = AmericanBinaryOption(BrownianStock(), strike=2.0)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 1.0, 1.0, 1.0],
-                [1.0, 1.0, 1.0, 2.0],
-                [1.9, 2.0, 2.1, 1.0],
-            ]
+            [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0], [1.9, 2.0, 2.1, 1.0]]
         )
         result = liability.payoff()
         expect = torch.tensor([0.0, 1.0, 1.0, 1.0])
@@ -29,11 +25,7 @@ class TestAmericanBinaryOption:
 
         liability = AmericanBinaryOption(BrownianStock(), strike=1.0, call=False)
         liability.underlier.prices = torch.tensor(
-            [
-                [2.0, 2.0, 2.0, 2.0],
-                [2.0, 2.0, 2.0, 1.0],
-                [1.1, 1.0, 0.9, 2.0],
-            ]
+            [[2.0, 2.0, 2.0, 2.0], [2.0, 2.0, 2.0, 1.0], [1.1, 1.0, 0.9, 2.0]]
         )
         result = liability.payoff()
         expect = torch.tensor([0.0, 1.0, 1.0, 1.0])

--- a/tests/instruments/test_european.py
+++ b/tests/instruments/test_european.py
@@ -17,11 +17,7 @@ class TestEuropeanOption:
     def test_payoff(self):
         liability = EuropeanOption(BrownianStock(), strike=2.0)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 1.0, 1.0, 1.0],
-                [1.0, 1.0, 1.0, 1.0],
-                [1.9, 2.0, 2.1, 3.0],
-            ]
+            [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [1.9, 2.0, 2.1, 3.0]]
         )
         result = liability.payoff()
         expect = torch.tensor([0.0, 0.0, 0.1, 1.0])

--- a/tests/instruments/test_european_binary.py
+++ b/tests/instruments/test_european_binary.py
@@ -17,11 +17,7 @@ class TestEuropeanBinaryOption:
     def test_payoff(self):
         liability = EuropeanBinaryOption(BrownianStock(), strike=2.0)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 1.0, 1.0, 1.0],
-                [3.0, 1.0, 1.0, 1.0],
-                [1.9, 2.0, 2.1, 3.0],
-            ]
+            [[1.0, 1.0, 1.0, 1.0], [3.0, 1.0, 1.0, 1.0], [1.9, 2.0, 2.1, 3.0]]
         )
         result = liability.payoff()
         expect = torch.tensor([0.0, 1.0, 1.0, 1.0])

--- a/tests/instruments/test_lookback.py
+++ b/tests/instruments/test_lookback.py
@@ -17,11 +17,7 @@ class TestLookbackOption:
     def test_payoff(self):
         liability = LookbackOption(BrownianStock(), strike=3.0)
         liability.underlier.prices = torch.tensor(
-            [
-                [1.0, 2.0, 3.0],
-                [2.0, 3.0, 2.0],
-                [1.5, 4.0, 1.0],
-            ]
+            [[1.0, 2.0, 3.0], [2.0, 3.0, 2.0], [1.5, 4.0, 1.0]]
         )
         # max [2.0, 4.0, 3.0]
         result = liability.payoff()
@@ -31,11 +27,7 @@ class TestLookbackOption:
     def test_payoff_put(self):
         liability = LookbackOption(BrownianStock(), strike=3.0, call=False)
         liability.underlier.prices = torch.tensor(
-            [
-                [3.0, 6.0, 3.0],
-                [2.0, 5.0, 4.0],
-                [2.5, 4.0, 5.0],
-            ]
+            [[3.0, 6.0, 3.0], [2.0, 5.0, 4.0], [2.5, 4.0, 5.0]]
         )
         # min [2.0, 4.0, 3.0]
         result = liability.payoff()


### PR DESCRIPTION
This Release includes the following chores:

* Add GitHub Actions `bump.yml`: Creates a PR that bumps version number when a branch named "release/*" is created.
* Add a job `format` to GH Actions `ci.yml`: Creates a PR that formats the files when linting fails.
* Add `Makefile` to install, test, lint, and format locally.
* Resolve 403 error of "Open in Colab" button in README.
* Drop flake8.
* Tweak `example_readme.ipynb` (install pfhedge via pip, prompt user to use GPU on Google Colab)