### PR TITLE
torch requirement changing to 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/pfnet-research/pfhedge"
 
 [tool.poetry.dependencies]
 python = "^3.7.12"
-torch = "^1.10.0"
+torch = "^1.9.0"
 tqdm = "^4.62.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Because of unknown bugs in torch 1.10.0 and above, I faced implementation difficulties in my code.
However, because of pfhedge requirements, torch cannot be downgraded.
Can we downgrade the torch requirements of pfhedge?
(Those situations frequently occur. Thus, I thank, at least, the last 2 major versions should be supported)

Thank you for your consideration in advance.