### PR TITLE
Fix 0/0 issue

### DIFF
--- a/pfhedge/nn/functional.py
+++ b/pfhedge/nn/functional.py
@@ -524,13 +524,10 @@ def d1(log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor) -> T
         raise ValueError("all elements in volatility have to be non-negative")
     numerator = s + (v.square() / 2) * t
     denominator = v * t.sqrt()
-    zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
-    denominator = torch.where(
-        zero_div_zero_mask,
-        torch.zeros_like(denominator) + torch.finfo().tiny,
-        denominator,
+    output = numerator / denominator
+    return torch.where(
+        (numerator == 0).logical_and(denominator == 0), torch.zeros_like(output), output
     )
-    return numerator.div(denominator)
 
 
 def d2(log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor) -> Tensor:
@@ -562,13 +559,10 @@ def d2(log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor) -> T
         raise ValueError("all elements in volatility have to be non-negative")
     numerator = s - (v.square() / 2) * t
     denominator = v * t.sqrt()
-    zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
-    denominator = torch.where(
-        zero_div_zero_mask,
-        torch.zeros_like(denominator) + torch.finfo().tiny,
-        denominator,
+    output = numerator / denominator
+    return torch.where(
+        (numerator == 0).logical_and(denominator == 0), torch.zeros_like(output), output
     )
-    return numerator.div(denominator)
 
 
 def ww_width(

--- a/pfhedge/nn/modules/bs/american_binary.py
+++ b/pfhedge/nn/modules/bs/american_binary.py
@@ -158,6 +158,7 @@ class BSAmericanBinaryOption(BSModuleMixin):
         """
         s, t, v = broadcast_all(log_moneyness, time_to_maturity, volatility)
         spor = s.exp() * self.strike
+        # ToDo: fix 0/0 issue
         p = (
             npdf(d2(s, t, v)) / (spor * v * t.sqrt())
             - (1 - ncdf(d2(-s, t, v))) / self.strike

--- a/pfhedge/nn/modules/bs/european.py
+++ b/pfhedge/nn/modules/bs/european.py
@@ -141,13 +141,12 @@ class BSEuropeanOption(BSModuleMixin):
         price = self.strike * s.exp()
         numerator = npdf(d1(s, t, v))
         denominator = price * v * t.sqrt()
-        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
-        denominator = torch.where(
-            zero_div_zero_mask,
-            torch.zeros_like(denominator) + torch.finfo().tiny,
-            denominator,
+        output = numerator / denominator
+        return torch.where(
+            (numerator == 0).logical_and(denominator == 0),
+            torch.zeros_like(output),
+            output,
         )
-        gamma = numerator / denominator
 
         return gamma
 
@@ -204,13 +203,12 @@ class BSEuropeanOption(BSModuleMixin):
         price = self.strike * s.exp()
         numerator = -npdf(d1(s, t, v)) * price * v
         denominator = 2 * t.sqrt()
-        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
-        denominator = torch.where(
-            zero_div_zero_mask,
-            torch.zeros_like(denominator) + torch.finfo().tiny,
-            denominator,
+        output = numerator / denominator
+        return torch.where(
+            (numerator == 0).logical_and(denominator == 0),
+            torch.zeros_like(output),
+            output,
         )
-        return numerator.div(denominator)
 
     def price(
         self, log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor

--- a/pfhedge/nn/modules/bs/european.py
+++ b/pfhedge/nn/modules/bs/european.py
@@ -148,8 +148,6 @@ class BSEuropeanOption(BSModuleMixin):
             output,
         )
 
-        return gamma
-
     def vega(
         self, log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor
     ) -> Tensor:

--- a/pfhedge/nn/modules/bs/european.py
+++ b/pfhedge/nn/modules/bs/european.py
@@ -139,7 +139,15 @@ class BSEuropeanOption(BSModuleMixin):
 
         s, t, v = broadcast_all(log_moneyness, time_to_maturity, volatility)
         price = self.strike * s.exp()
-        gamma = npdf(d1(s, t, v)) / (price * v * t.sqrt())
+        numerator = npdf(d1(s, t, v))
+        denominator = price * v * t.sqrt()
+        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
+        denominator = torch.where(
+            zero_div_zero_mask,
+            torch.zeros_like(denominator) + torch.finfo().tiny,
+            denominator,
+        )
+        gamma = numerator / denominator
 
         return gamma
 
@@ -194,8 +202,15 @@ class BSEuropeanOption(BSModuleMixin):
         """
         s, t, v = broadcast_all(log_moneyness, time_to_maturity, volatility)
         price = self.strike * s.exp()
-        theta = -npdf(d1(s, t, v)) * price * v / (2 * t.sqrt())
-        return theta
+        numerator = -npdf(d1(s, t, v)) * price * v
+        denominator = 2 * t.sqrt()
+        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
+        denominator = torch.where(
+            zero_div_zero_mask,
+            torch.zeros_like(denominator) + torch.finfo().tiny,
+            denominator,
+        )
+        return numerator.div(denominator)
 
     def price(
         self, log_moneyness: Tensor, time_to_maturity: Tensor, volatility: Tensor

--- a/pfhedge/nn/modules/bs/european_binary.py
+++ b/pfhedge/nn/modules/bs/european_binary.py
@@ -144,7 +144,16 @@ class BSEuropeanBinaryOption(BSModuleMixin):
         s, t, v = broadcast_all(log_moneyness, time_to_maturity, volatility)
 
         spot = s.exp() * self.strike
-        delta = npdf(d2(s, t, v)) / (spot * v * t.sqrt())
+
+        numerator = npdf(d2(s, t, v))
+        denominator = spot * v * t.sqrt()
+        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
+        denominator = torch.where(
+            zero_div_zero_mask,
+            torch.zeros_like(denominator) + torch.finfo().tiny,
+            denominator,
+        )
+        delta = numerator.div(denominator)
         delta = -delta if not self.call else delta  # put-call parity
 
         return delta

--- a/pfhedge/nn/modules/bs/european_binary.py
+++ b/pfhedge/nn/modules/bs/european_binary.py
@@ -147,13 +147,12 @@ class BSEuropeanBinaryOption(BSModuleMixin):
 
         numerator = npdf(d2(s, t, v))
         denominator = spot * v * t.sqrt()
-        zero_div_zero_mask = (numerator == 0).logical_and(denominator == 0)
-        denominator = torch.where(
-            zero_div_zero_mask,
-            torch.zeros_like(denominator) + torch.finfo().tiny,
-            denominator,
+        delta = numerator / denominator
+        delta = torch.where(
+            (numerator == 0).logical_and(denominator == 0),
+            torch.zeros_like(delta),
+            delta,
         )
-        delta = numerator.div(denominator)
         delta = -delta if not self.call else delta  # put-call parity
 
         return delta

--- a/pfhedge/nn/modules/mlp.py
+++ b/pfhedge/nn/modules/mlp.py
@@ -64,7 +64,7 @@ class MultiLayerPerceptron(Sequential):
           (8): Linear(in_features=32, out_features=1, bias=True)
           (9): Identity()
         )
-        >>> _ = m(torch.empty(3, 2))
+        >>> _ = m(torch.zeros(3, 2))
         >>> m
         MultiLayerPerceptron(
           (0): Linear(in_features=2, out_features=32, bias=True)

--- a/pfhedge/nn/modules/naked.py
+++ b/pfhedge/nn/modules/naked.py
@@ -22,7 +22,7 @@ class Naked(Module):
         >>> from pfhedge.nn import Naked
         >>>
         >>> m = Naked()
-        >>> input = torch.empty((2, 3))
+        >>> input = torch.zeros((2, 3))
         >>> m(input)
         tensor([[0.],
                 [0.]])

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -85,7 +85,7 @@ class TestMoneyness(_TestFeature):
 
     # def test_getitem_deprecation_warning(self):
     #     derivative = EuropeanOption(BrownianStock())
-    #     spot = torch.empty(2, 3)
+    #     spot = torch.zeros(2, 3)
     #     derivative.underlier.register_buffer("spot", spot)
     #     f = Moneyness().of(derivative)
 
@@ -95,7 +95,7 @@ class TestMoneyness(_TestFeature):
     @pytest.mark.filterwarnings("ignore")
     def test_getitem_get(self):
         derivative = EuropeanOption(BrownianStock())
-        spot = torch.empty(2, 3)
+        spot = torch.zeros(2, 3)
         derivative.underlier.register_buffer("spot", spot)
         f = Moneyness().of(derivative)
         assert_close(f.get(0), f[0])
@@ -143,7 +143,7 @@ class TestLogMoneyness(_TestFeature):
 class TestTimeToMaturity(_TestFeature):
     def test(self):
         derivative = EuropeanOption(BrownianStock(dt=0.1), maturity=0.2)
-        derivative.ul().register_buffer("spot", torch.empty(2, 3))
+        derivative.ul().register_buffer("spot", torch.zeros(2, 3))
         f = TimeToMaturity().of(derivative)
 
         result = f.get(0)
@@ -168,7 +168,7 @@ class TestTimeToMaturity(_TestFeature):
 
     def test_2(self):
         derivative = EuropeanOption(BrownianStock(dt=0.1), maturity=0.15)
-        derivative.underlier.register_buffer("spot", torch.empty(2, 3))
+        derivative.underlier.register_buffer("spot", torch.zeros(2, 3))
         f = TimeToMaturity().of(derivative)
 
         result = f.get(0)
@@ -211,7 +211,7 @@ class TestVolatility(_TestFeature):
     @pytest.mark.parametrize("sigma", [0.2, 0.1])
     def test_constant_volatility(self, sigma):
         derivative = EuropeanOption(BrownianStock(sigma=sigma))
-        derivative.underlier.register_buffer("spot", torch.empty(2, 3))
+        derivative.underlier.register_buffer("spot", torch.zeros(2, 3))
 
         f = Volatility().of(derivative)
 
@@ -276,7 +276,7 @@ class TestVariance(_TestFeature):
     @pytest.mark.parametrize("sigma", [0.2, 0.1])
     def test_constant_volatility(self, sigma):
         derivative = EuropeanOption(BrownianStock(sigma=sigma))
-        derivative.underlier.register_buffer("spot", torch.empty(2, 3))
+        derivative.underlier.register_buffer("spot", torch.zeros(2, 3))
 
         f = Variance().of(derivative)
 
@@ -500,7 +500,7 @@ class TestZeros(_TestFeature):
     def test(self):
         torch.manual_seed(42)
         derivative = EuropeanOption(BrownianStock())
-        derivative.ul().register_buffer("spot", torch.empty(2, 3))
+        derivative.ul().register_buffer("spot", torch.zeros(2, 3))
 
         f = Zeros().of(derivative)
 
@@ -543,7 +543,7 @@ class TestEmpty(_TestFeature):
     def test(self):
         torch.manual_seed(42)
         derivative = EuropeanOption(BrownianStock())
-        derivative.underlier.register_buffer("spot", torch.empty(2, 3))
+        derivative.underlier.register_buffer("spot", torch.zeros(2, 3))
 
         f = Empty().of(derivative)
 

--- a/tests/instruments/primary/test_brownian.py
+++ b/tests/instruments/primary/test_brownian.py
@@ -37,13 +37,13 @@ class TestBrownianStock:
     def test_register_buffer(self):
         s = BrownianStock()
         with pytest.raises(TypeError):
-            s.register_buffer(None, torch.empty(10))
+            s.register_buffer(None, torch.zeros(10))
         with pytest.raises(KeyError):
-            s.register_buffer("a.b", torch.empty(10))
+            s.register_buffer("a.b", torch.zeros(10))
         with pytest.raises(KeyError):
-            s.register_buffer("", torch.empty(10))
+            s.register_buffer("", torch.zeros(10))
         with pytest.raises(KeyError):
-            s.register_buffer("simulate", torch.empty(10))
+            s.register_buffer("simulate", torch.zeros(10))
         with pytest.raises(TypeError):
             s.register_buffer("a", torch.nn.ReLU())
 
@@ -73,7 +73,7 @@ class TestBrownianStock:
                 pass
 
             def simulate(self):
-                self.register_buffer("a", torch.empty(10))
+                self.register_buffer("a", torch.zeros(10))
 
         with pytest.raises(AttributeError):
             MyPrimary().simulate()

--- a/tests/nn/modules/bs/_base.py
+++ b/tests/nn/modules/bs/_base.py
@@ -10,15 +10,15 @@ class _TestBSModule:
         M_2 = 11
         H_in = len(module.inputs())
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         out = method(*(input[..., i] for i in range(H_in)))
         assert out.size() == torch.Size((N,))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         out = method(*(input[..., i] for i in range(H_in)))
         assert out.size() == torch.Size((N, M_1))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         out = method(*(input[..., i] for i in range(H_in)))
         assert out.size() == torch.Size((N, M_1, M_2))
 
@@ -43,14 +43,14 @@ class _TestBSModule:
         M_2 = 11
         H_in = len(module.inputs())
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         out = module(input)
         assert out.size() == torch.Size((N, 1))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         out = module(input)
         assert out.size() == torch.Size((N, M_1, 1))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         out = module(input)
         assert out.size() == torch.Size((N, M_1, M_2, 1))

--- a/tests/nn/modules/bs/test_bs.py
+++ b/tests/nn/modules/bs/test_bs.py
@@ -46,11 +46,11 @@ class TestBlackScholes:
         M_1 = 12
         M_2 = 13
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         assert m(input).size() == torch.Size((N, 1))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         assert m(input).size() == torch.Size((N, M_1, 1))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))

--- a/tests/nn/modules/bs/test_european.py
+++ b/tests/nn/modules/bs/test_european.py
@@ -207,6 +207,29 @@ class TestBSEuropeanOption(_TestBSModule):
         expect = torch.full_like(result, -0.4601721)
         assert_close(result, expect)
 
+    @pytest.mark.parametrize("call", [True, False])
+    def test_delta_3(self, call: bool):
+        m = BSEuropeanOption(call=call)
+        with pytest.raises(ValueError):
+            m.delta(torch.tensor(0.0), torch.tensor(-1.0), torch.tensor(0.2))
+        with pytest.raises(ValueError):
+            m.delta(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(-0.2))
+        result = m.delta(torch.tensor(1.0), torch.tensor(1.0), torch.tensor(0))
+        expect = torch.full_like(result, 1.0 if call else 0.0)
+        assert_close(result, expect)
+        result = m.delta(torch.tensor(1.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 1.0 if call else 0.0)
+        assert_close(result, expect)
+        result = m.delta(torch.tensor(1.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 1.0 if call else 0.0)
+        assert_close(result, expect)
+        result = m.delta(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 0.5 if call else -0.5)
+        assert_close(result, expect)
+        result = m.delta(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 0.5 if call else -0.5)
+        assert_close(result, expect)
+
     def test_gamma_1(self):
         m = BSEuropeanOption()
         result = m.gamma(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(0.2))
@@ -219,6 +242,29 @@ class TestBSEuropeanOption(_TestBSModule):
         expect = torch.full_like(result, 1.9847627374)
         assert_close(result, expect)
 
+    @pytest.mark.parametrize("call", [True, False])
+    def test_gamma_3(self, call: bool):
+        m = BSEuropeanOption(call=call)
+        with pytest.raises(ValueError):
+            m.gamma(torch.tensor(0.0), torch.tensor(-1.0), torch.tensor(0.2))
+        with pytest.raises(ValueError):
+            m.gamma(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(-0.2))
+        result = m.gamma(torch.tensor(1.0), torch.tensor(1.0), torch.tensor(0))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.gamma(torch.tensor(1.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.gamma(torch.tensor(1.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.gamma(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, float("inf"))
+        assert_close(result, expect)
+        result = m.gamma(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, float("inf"))
+        assert_close(result, expect)
+
     def test_price_1(self):
         m = BSEuropeanOption()
         result = m.price(0.0, 1.0, 0.2)
@@ -229,6 +275,35 @@ class TestBSEuropeanOption(_TestBSModule):
         m = BSEuropeanOption(call=False)
         result = m.price(0.0, 1.0, 0.2)
         expect = torch.full_like(result, 0.0796557924)
+        assert_close(result, expect)
+
+    @pytest.mark.parametrize("call", [True, False])
+    def test_price_3(self, call: bool):
+        m = BSEuropeanOption(call=call)
+        with pytest.raises(ValueError):
+            m.price(torch.tensor(0.0), torch.tensor(-1.0), torch.tensor(0.2))
+        with pytest.raises(ValueError):
+            m.price(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(-0.2))
+        result = m.price(
+            torch.tensor(1.0 if call else -1.0), torch.tensor(1.0), torch.tensor(0)
+        )
+        expect = torch.full_like(result, 1.718282 if call else 0.632121)
+        assert_close(result, expect)
+        result = m.price(
+            torch.tensor(1.0 if call else -1.0), torch.tensor(0.0), torch.tensor(0.1)
+        )
+        expect = torch.full_like(result, 1.718282 if call else 0.632121)
+        assert_close(result, expect)
+        result = m.price(
+            torch.tensor(1.0 if call else -1.0), torch.tensor(0.0), torch.tensor(0.0)
+        )
+        expect = torch.full_like(result, 1.718282 if call else 0.632121)
+        assert_close(result, expect)
+        result = m.price(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.price(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 0.0)
         assert_close(result, expect)
 
     def test_implied_volatility(self):
@@ -251,13 +326,36 @@ class TestBSEuropeanOption(_TestBSModule):
         expect = torch.tensor([0.1261, 0.1782, 0.2182])
         assert_close(result, expect, atol=1e-3, rtol=0)
 
+    @pytest.mark.parametrize("call", [True, False])
+    def test_vega_2(self, call: bool):
+        m = BSEuropeanOption(call=call)
+        with pytest.raises(ValueError):
+            m.vega(torch.tensor(0.0), torch.tensor(-1.0), torch.tensor(0.2))
+        with pytest.raises(ValueError):
+            m.vega(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(-0.2))
+        result = m.vega(torch.tensor(0.1), torch.tensor(1.0), torch.tensor(0))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.vega(torch.tensor(0.1), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.vega(torch.tensor(0.1), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.vega(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+        result = m.vega(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, 0.0)
+        assert_close(result, expect)
+
     def test_vega_and_gamma(self):
         m = BSEuropeanOption()
         # vega = spot^2 * sigma * (T - t) * gamma
         # See Chapter 5 Appendix A, Bergomi "Stochastic volatility modeling"
-        spot = torch.tensor([0.9, 1.0, 1.1])
-        t = torch.tensor([0.1, 0.2, 0.3])
-        v = torch.tensor([0.1, 0.2, 0.3])
+        spot = torch.tensor([0.9, 1.0, 1.1, 1.1, 1.1, 1.1])
+        t = torch.tensor([0.1, 0.2, 0.3, 0.0, 0.0, 0.1])
+        v = torch.tensor([0.1, 0.2, 0.3, 0.0, 0.2, 0.0])
         vega = m.vega(spot.log(), t, v)
         gamma = m.gamma(spot.log(), t, v)
         assert_close(vega, spot.square() * v * t * gamma, atol=1e-3, rtol=0)
@@ -272,6 +370,29 @@ class TestBSEuropeanOption(_TestBSModule):
         )
         expect = torch.tensor([-12.6094, -8.9117, -7.2727])
         assert_close(result, expect, atol=1e-3, rtol=0)
+
+    @pytest.mark.parametrize("call", [True, False])
+    def test_theta_2(self, call: bool):
+        m = BSEuropeanOption(call=call)
+        with pytest.raises(ValueError):
+            m.theta(torch.tensor(0.0), torch.tensor(-1.0), torch.tensor(0.2))
+        with pytest.raises(ValueError):
+            m.theta(torch.tensor(0.0), torch.tensor(1.0), torch.tensor(-0.2))
+        result = m.theta(torch.tensor(0.1), torch.tensor(1.0), torch.tensor(0))
+        expect = torch.full_like(result, -0.0)
+        assert_close(result, expect)
+        result = m.theta(torch.tensor(0.1), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, -0.0)
+        assert_close(result, expect)
+        result = m.theta(torch.tensor(0.1), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, -0.0)
+        assert_close(result, expect)
+        result = m.theta(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.1))
+        expect = torch.full_like(result, -float("inf"))
+        assert_close(result, expect)
+        result = m.theta(torch.tensor(0.0), torch.tensor(0.0), torch.tensor(0.0))
+        expect = torch.full_like(result, -0.0)
+        assert_close(result, expect)
 
     def test_example(self):
         from pfhedge.instruments import BrownianStock

--- a/tests/nn/modules/test_hedger.py
+++ b/tests/nn/modules/test_hedger.py
@@ -243,23 +243,23 @@ Hedger(
         M_2 = 6
         H_in = 3
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         m = Hedger(MultiLayerPerceptron(), ["empty"])
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))
 
         model = BlackScholes(deriv)
         m = Hedger(model, model.inputs())
-        input = torch.empty((N, M_1, M_2, len(model.inputs())))
+        input = torch.zeros((N, M_1, M_2, len(model.inputs())))
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))
 
         model = WhalleyWilmott(deriv)
         m = Hedger(model, model.inputs())
-        input = torch.empty((N, M_1, M_2, len(model.inputs())))
+        input = torch.zeros((N, M_1, M_2, len(model.inputs())))
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))
 
         model = Naked()
         m = Hedger(model, ["empty"])
-        input = torch.empty((N, M_1, M_2, 10))
+        input = torch.zeros((N, M_1, M_2, 10))
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))
 
     @pytest.mark.parametrize("h_in", [1, 2, 3])

--- a/tests/nn/modules/test_mlp.py
+++ b/tests/nn/modules/test_mlp.py
@@ -27,7 +27,7 @@ class TestMultiLayerPerceptron:
         m = MultiLayerPerceptron(
             n_layers=n_layers, n_units=n_units, out_features=out_features
         )
-        _ = m(torch.empty((1, in_features)))
+        _ = m(torch.zeros((1, in_features)))
 
         for i in range(n_layers + 1):
             linear = m[2 * i]
@@ -56,15 +56,15 @@ class TestMultiLayerPerceptron:
         M_2 = 13
         H_out = 14
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         m = MultiLayerPerceptron(H_in, H_out)
         assert m(input).size() == torch.Size((N, H_out))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         m = MultiLayerPerceptron(H_in, H_out)
         assert m(input).size() == torch.Size((N, M_1, H_out))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         m = MultiLayerPerceptron(H_in, H_out)
         assert m(input).size() == torch.Size((N, M_1, M_2, H_out))
 
@@ -75,14 +75,14 @@ class TestMultiLayerPerceptron:
         M_2 = 13
         H_out = 14
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         m = MultiLayerPerceptron(out_features=H_out)
         assert m(input).size() == torch.Size((N, H_out))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         m = MultiLayerPerceptron(out_features=H_out)
         assert m(input).size() == torch.Size((N, M_1, H_out))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         m = MultiLayerPerceptron(out_features=H_out)
         assert m(input).size() == torch.Size((N, M_1, M_2, H_out))

--- a/tests/nn/modules/test_naked.py
+++ b/tests/nn/modules/test_naked.py
@@ -13,7 +13,7 @@ class TestNaked:
     @pytest.mark.parametrize("n_features", [1, 10])
     def test(self, n_paths, n_features):
         m = Naked()
-        input = torch.empty((n_paths, n_features))
+        input = torch.zeros((n_paths, n_features))
         assert torch.equal(m(input), torch.zeros((n_paths, 1)))
 
     def test_shape(self):
@@ -23,14 +23,14 @@ class TestNaked:
         M_2 = 14
         H_out = 15
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         m = Naked(H_out)
         assert m(input).size() == torch.Size((N, H_out))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         m = Naked(H_out)
         assert m(input).size() == torch.Size((N, M_1, H_out))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         m = Naked(H_out)
         assert m(input).size() == torch.Size((N, M_1, M_2, H_out))

--- a/tests/nn/modules/test_ww.py
+++ b/tests/nn/modules/test_ww.py
@@ -46,13 +46,13 @@ WhalleyWilmott(
         M_1 = 11
         M_2 = 12
 
-        input = torch.empty((N, H_in))
+        input = torch.zeros((N, H_in))
         assert m(input).size() == torch.Size((N, 1))
 
-        input = torch.empty((N, M_1, H_in))
+        input = torch.zeros((N, M_1, H_in))
         assert m(input).size() == torch.Size((N, M_1, 1))
 
-        input = torch.empty((N, M_1, M_2, H_in))
+        input = torch.zeros((N, M_1, M_2, H_in))
         assert m(input).size() == torch.Size((N, M_1, M_2, 1))
 
     def test(self):

--- a/tests/nn/test_functional.py
+++ b/tests/nn/test_functional.py
@@ -52,9 +52,9 @@ def test_topp(p, largest):
 
 def test_topp_error():
     with pytest.raises(RuntimeError):
-        topp(torch.empty(100), 1.1)
+        topp(torch.zeros(100), 1.1)
     with pytest.raises(RuntimeError):
-        topp(torch.empty(100), -0.1)
+        topp(torch.zeros(100), -0.1)
 
 
 def test_expected_shortfall():
@@ -109,9 +109,9 @@ def test_leaky_clamp():
 
 
 def test_clamp_error_invalid_inverted_output():
-    input = torch.empty(10)
-    min = torch.empty(10)
-    max = torch.empty(10)
+    input = torch.zeros(10)
+    min = torch.zeros(10)
+    max = torch.zeros(10)
     with pytest.raises(ValueError):
         _ = leaky_clamp(input, min, max, inverted_output="min")
     with pytest.raises(ValueError):
@@ -197,9 +197,9 @@ def test_terminal_value():
 
 
 def test_terminal_value_unmatched_shape():
-    spot = torch.empty((10, 20))
-    unit = torch.empty((10, 20))
-    payoff = torch.empty(10)
+    spot = torch.zeros((10, 20))
+    unit = torch.zeros((10, 20))
+    payoff = torch.zeros(10)
     with pytest.raises(RuntimeError):
         _ = terminal_value(spot, unit[:-1])
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
fix #484 

This fix includes:
 - full fix for BS d1/d2, European options with additional test
 - partial fix for European binary (because the current version mainly uses autogreeks) **w/o additional test**

This fix also fixes the lookback option indirectly.

Because other options' BS modules mainly use autogreeks, I didn't make modifications except for adding notes.