### PR TITLE
Adding is_listed

### DIFF
--- a/pfhedge/instruments/base.py
+++ b/pfhedge/instruments/base.py
@@ -21,6 +21,11 @@ class BaseInstrument(ABC):
     def spot(self) -> Tensor:
         """Returns the spot price of self."""
 
+    @property
+    @abstractmethod
+    def is_listed(self) -> bool:
+        """Returns whether it is listed or not."""
+
     @abstractmethod
     @no_type_check
     def simulate(self, n_paths: int, time_horizon: float, **kwargs) -> None:

--- a/pfhedge/instruments/derivative/base.py
+++ b/pfhedge/instruments/derivative/base.py
@@ -136,6 +136,10 @@ class BaseDerivative(BaseInstrument):
         self.pricer = pricer
         self.cost = cost
 
+    @property
+    def is_listed(self) -> bool:
+        return self.pricer is not None
+
     def add_clause(
         self, name: str, clause: Callable[["BaseDerivative", Tensor], Tensor]
     ) -> None:

--- a/pfhedge/instruments/primary/base.py
+++ b/pfhedge/instruments/primary/base.py
@@ -154,6 +154,10 @@ class BasePrimary(BaseInstrument):
             "Asset may not be simulated."
         )
 
+    @property
+    def is_listed(self) -> bool:
+        return True
+
     def to(self: T, *args, **kwargs) -> T:
         device, dtype, *_ = self._parse_to(*args, **kwargs)
 

--- a/tests/instruments/derivative/test_european.py
+++ b/tests/instruments/derivative/test_european.py
@@ -214,6 +214,12 @@ EuropeanOption(
         with pytest.raises(ValueError):
             _ = derivative.spot
 
+    def test_us_listed(self):
+        derivative = EuropeanOption(BrownianStock())
+        assert not derivative.is_listed
+        derivative.list(pricer=lambda x: x)
+        assert derivative.is_listed
+
     def test_init_dtype_deprecated(self):
         with pytest.raises(DeprecationWarning):
             _ = EuropeanOption(BrownianStock(), dtype=torch.float64)

--- a/tests/instruments/primary/test_brownian.py
+++ b/tests/instruments/primary/test_brownian.py
@@ -213,3 +213,7 @@ class TestBrownianStock:
 
         s = BrownianStock()
         assert s.cuda(1).device == torch.device("cuda:1")
+
+    def test_is_listed(self):
+        s = BrownianStock()
+        assert s.is_listed


### PR DESCRIPTION
My suggestion for #274 

I think it is better to implement `is_listed` to Primary because `is_listed` can be used as a previous check for `spot` availability.