### PR TITLE
Fixed warning with pip install

### DIFF
--- a/examples/example_readme.ipynb
+++ b/examples/example_readme.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install pfhedge"
+    "%pip install pfhedge"
    ]
   },
   {


### PR DESCRIPTION
Here's a small fix for a warning in the Jupyter notebook

`Use '%pip install' instead of '!pip install'`