### PR TITLE
Fix EuropeanForwardStartOption

### DIFF
--- a/pfhedge/instruments/derivative/cliquet.py
+++ b/pfhedge/instruments/derivative/cliquet.py
@@ -9,9 +9,10 @@ from pfhedge.nn.functional import european_forward_start_payoff
 
 from ..primary.base import BasePrimary
 from .base import BaseDerivative
+from .base import OptionMixin
 
 
-class EuropeanForwardStartOption(BaseDerivative):
+class EuropeanForwardStartOption(BaseDerivative, OptionMixin):
     r"""European forward start option.
 
     The payoff is given by


### PR DESCRIPTION
I found that `EuropeanForwardStartOption` in `pfhedge.instruments.derivative.cliquet.py` doesn't inherit `pfhedge.instruments.derivative.base.OptionMixin`, so features such as moneyness, etc. can't be computed.

This is just a simple fix, just adding `OptionMixin` as a parent for the `EuropeanForwardStartOption` class.

Thanks! :)